### PR TITLE
Tester 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ tests: context [
         poc/register "my-book" book
         
         result: poc/registered "my-book"
-        tester/assert-true result none
+        tester/assert-true result
     ]
 ]
 
@@ -71,7 +71,7 @@ Console output:
 ```bash
 ./red -s test.red 
 --------- Tester ----------
-Version 0.0.1
+Version 0.0.2
 
 [test] test-registered-item [Success]
 

--- a/run-all-tests.red
+++ b/run-all-tests.red
@@ -1,31 +1,15 @@
 Red [
     Title: "Run all tests"
-    Description: "Will detect and execute all .red tests under /tests directory"
+    Description: "Will detect and execute all "****-tests.red" tests under /tests directory"
     Author: "Mateusz Palichleb"
-    Supports: "Linux,Mac"
     File: %run-all-tests.red
 ]
 
-;-- definitions
-list: ""
-command: "ls tests"
+files: read %tests/
 
-;-- executing command
-call/output command list
-
-; convert output to series string
-parse list [some [to "^/" change "^/" " "]]
-list: trim list
-parse list [some [to " " change " " "^" ^""]]
-list: append append "[^"" list "^"]"
-
-; convert string to series
-series: do list
-
-; execute each file like "****-tests.red" from "/tests" directory
-foreach element series [	
-    if find element "-tests.red" [
-        test-file-path: rejoin ["tests/" element]
+foreach file files [	
+    if find file "-tests.red" [
+        test-file-path: rejoin ["tests/" file]
         test-file: to file! test-file-path
 	do test-file
     ]

--- a/src/tester.red
+++ b/src/tester.red
@@ -41,6 +41,7 @@ tester: context [
         foreach test tests [
 	    prin rejoin ["[test] " test " "]
 	    errors-before: length? errors
+            error-expected: false
             actual-test-name: to string! test
 
             if execute-setup [
@@ -68,11 +69,11 @@ tester: context [
         end-time: now/time/precise/utc
 
         diff: to float! end-time - start-time
-        print rejoin ["^/Execution time: " diff " sec^/"] 
+        print rejoin ["^/Execution time: " diff " sec"] 
 
         errors-count: length? errors
 	if errors-count > 0 [
-            print "---- Errors ----^/"
+            print "^/---- Errors ----^/"
 
             keys: reflect errors 'words
             foreach key keys [
@@ -89,15 +90,15 @@ tester: context [
             tests-passed: tests-passed + 1
         ] [
             size: length? errors
-	    issue: make error! [
-		code: none
-		type: 'user
-		id: 'message
-		arg1: "Expected value was 'true', but 'false' given."
+            issue: make error! [
+                code: none
+                type: 'user
+                id: 'message
+                arg1: "Expected value was 'true', but 'false' given."
                 where: 'assert-true
-	    ]
+            ]
             assertion: rejoin [actual-test-name "-assert-true-"]
-	    key: append assertion size
+            key: append assertion size
             put errors key issue
         ]
     ]

--- a/src/tester.red
+++ b/src/tester.red
@@ -4,13 +4,15 @@ Red [
     Purpose: "Be able to test Red language scripts"
     Author: "Mateusz Palichleb"
     File: %tester.red
-    Version: "0.0.1"
+    Version: "0.0.2"
 ]
 
 tester: context [
     /local tests-passed: 0
-    /local errors: make series![]
+    /local errors: make map![]
     /local execute-setup: false
+    /local error-expected: false
+    /local actual-test-name: ""
 
     run: func [
         testable[object!]
@@ -18,6 +20,7 @@ tester: context [
         print-title
 
         methods: words-of testable
+
         tests: []
         
         foreach method methods [
@@ -37,36 +40,70 @@ tester: context [
 
         foreach test tests [
 	    prin rejoin ["[test] " test " "]
-	    passed-before: tests-passed
+	    errors-before: length? errors
+            actual-test-name: to string! test
 
             if execute-setup [
                 do testable/setup
             ]
 
-            do test
-	    
-            either passed-before <> tests-passed [
-                print "[Success]"
+            was-error: error? result: try [
+                do test
+            ]
+
+	    either was-error and (not error-expected) [
+                put errors test result
             ] [
+                tests-passed: tests-passed + 1
+            ]
+            
+	    errors-after: length? errors
+            either errors-before <> errors-after [
                 print "[Failure]"
+            ] [
+                print "[Success]"
             ]
         ]
 
         end-time: now/time/precise/utc
 
         diff: to float! end-time - start-time
-        print rejoin ["^/Execution time: " diff " sec"] 
+        print rejoin ["^/Execution time: " diff " sec^/"] 
+
+        errors-count: length? errors
+	if errors-count > 0 [
+            print "---- Errors ----^/"
+
+            keys: reflect errors 'words
+            foreach key keys [
+                print rejoin [key ":^/" select errors key "^/"]
+            ]
+        ]
 	print "---------------------------"
     ]
 
     assert-true: func [
-        value[logic!] error 
+        value[logic!] 
     ] [
         either value [
             tests-passed: tests-passed + 1
         ] [
-            put errors error
+            size: length? errors
+	    issue: make error! [
+		code: none
+		type: 'user
+		id: 'message
+		arg1: "Expected value was 'true', but 'false' given."
+                where: 'assert-true
+	    ]
+            assertion: rejoin [actual-test-name "-assert-true-"]
+	    key: append assertion size
+            put errors key issue
         ]
+    ]
+
+    expect-error: does [
+        error-expected: true
     ]
 
     print-title: does [

--- a/tests/poc-tests.red
+++ b/tests/poc-tests.red
@@ -33,11 +33,8 @@ tests: context [
             name: append "name-" counter
             counter: counter + 1
 
-            was-error: error? result: try [
-                poc/register name not-allowed-type
-            ]
-
-            tester/assert-true was-error result
+            tester/expect-error
+            poc/register name not-allowed-type
         ]
     ]
 ]


### PR DESCRIPTION
Changes:
- assertion "tester/assert-true" now does not break test execution. Also it does not need error! object any more
- Tester catch now all error!-s from tests and collect inside `errors` map
- All errors are printed if they were catched at the end of testing execution